### PR TITLE
feat: [auth] username - 닉네임 중복 체크 기능 구현

### DIFF
--- a/src/main/java/site/travellaboratory/be/controller/auth/UserAuthController.java
+++ b/src/main/java/site/travellaboratory/be/controller/auth/UserAuthController.java
@@ -16,9 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 import site.travellaboratory.be.common.annotation.UserId;
 import site.travellaboratory.be.controller.auth.dto.UserJoinRequest;
 import site.travellaboratory.be.controller.auth.dto.UserJoinResponse;
+import site.travellaboratory.be.controller.auth.dto.UserLoginRequest;
+import site.travellaboratory.be.controller.auth.dto.UserNicknameRequest;
+import site.travellaboratory.be.controller.auth.dto.UserNicknameResponse;
 import site.travellaboratory.be.controller.jwt.dto.AccessTokenResponse;
 import site.travellaboratory.be.controller.jwt.dto.AuthTokenResponse;
-import site.travellaboratory.be.controller.auth.dto.UserLoginRequest;
 import site.travellaboratory.be.service.UserAuthService;
 
 @RestController
@@ -33,6 +35,13 @@ public class UserAuthController {
         @RequestBody UserJoinRequest userJoinRequest
     ) {
         return ResponseEntity.ok().body(userAuthService.join(userJoinRequest));
+    }
+
+    @PostMapping("/nickname")
+    public ResponseEntity<UserNicknameResponse> checkNicknameDuplicate(
+        @RequestBody UserNicknameRequest userNicknameRequest
+    ) {
+        return ResponseEntity.ok(userAuthService.isNicknameAvailable(userNicknameRequest));
     }
 
     @PostMapping("/login")

--- a/src/main/java/site/travellaboratory/be/controller/auth/dto/UserNicknameRequest.java
+++ b/src/main/java/site/travellaboratory/be/controller/auth/dto/UserNicknameRequest.java
@@ -1,0 +1,6 @@
+package site.travellaboratory.be.controller.auth.dto;
+
+public record UserNicknameRequest(
+    String nickname
+) {
+}

--- a/src/main/java/site/travellaboratory/be/controller/auth/dto/UserNicknameResponse.java
+++ b/src/main/java/site/travellaboratory/be/controller/auth/dto/UserNicknameResponse.java
@@ -1,0 +1,10 @@
+package site.travellaboratory.be.controller.auth.dto;
+
+public record UserNicknameResponse(
+    Boolean available
+) {
+    public static UserNicknameResponse from(Boolean available) {
+        return new UserNicknameResponse(
+            available);
+    }
+}

--- a/src/main/java/site/travellaboratory/be/service/UserAuthService.java
+++ b/src/main/java/site/travellaboratory/be/service/UserAuthService.java
@@ -8,12 +8,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.travellaboratory.be.common.exception.BeApplicationException;
 import site.travellaboratory.be.common.exception.ErrorCodes;
-import site.travellaboratory.be.controller.jwt.dto.AccessTokenResponse;
-import site.travellaboratory.be.controller.jwt.dto.AuthTokenResponse;
-import site.travellaboratory.be.controller.jwt.util.AuthTokenGenerator;
 import site.travellaboratory.be.controller.auth.dto.UserJoinRequest;
 import site.travellaboratory.be.controller.auth.dto.UserJoinResponse;
 import site.travellaboratory.be.controller.auth.dto.UserLoginRequest;
+import site.travellaboratory.be.controller.auth.dto.UserNicknameRequest;
+import site.travellaboratory.be.controller.auth.dto.UserNicknameResponse;
+import site.travellaboratory.be.controller.jwt.dto.AccessTokenResponse;
+import site.travellaboratory.be.controller.jwt.dto.AuthTokenResponse;
+import site.travellaboratory.be.controller.jwt.util.AuthTokenGenerator;
 import site.travellaboratory.be.domain.auth.pwanswer.PwAnswer;
 import site.travellaboratory.be.domain.auth.pwanswer.PwAnswerRepository;
 import site.travellaboratory.be.domain.auth.pwquestion.PwQuestion;
@@ -64,6 +66,16 @@ public class UserAuthService {
         pwAnswerRepository.save(pwAnswer);
 
         return UserJoinResponse.from(user);
+    }
+
+    public UserNicknameResponse isNicknameAvailable(UserNicknameRequest request) {
+        // 닉네임 중복 체크
+        userRepository.findByNickname(request.nickname()).ifPresent(it -> {
+            throw new BeApplicationException(ErrorCodes.AUTH_DUPLICATED_NICK_NAME,
+                HttpStatus.CONFLICT);
+        });
+
+        return UserNicknameResponse.from(true);
     }
 
     @Transactional


### PR DESCRIPTION
## 🧾 PR 관련 설명
- **작업 이유**:회원가입 시 닉네임 중복 체크 기능 구현

- **관련 이슈**: 해결하는 이슈 번호를 적습니다. 예: "Closes #123" 없으면 ❌

<br/>

## ✨ 주요 작업 내용
-  닉네임 중복 체크 기능 구현

<br/>

## ✅ 체크리스트
- [x] Build 성공?!
- [ ] Test 작성 완료?!
- [ ] 필요한 경우 문서를 업데이트했습니다.

<br/>

## 👓 리뷰어가 중점적으로 확인해야 하는 부분
- 이런 걸 신경쓰세요 

<br/>
