### PR TITLE
feat: [schedule] ScheduleGeneral 에만 있던 duration_time, expense, memo 를 ArticleSchedule (공통) 으로 수정

### DIFF
--- a/src/main/java/site/travellaboratory/be/common/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/site/travellaboratory/be/common/exceptionhandler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import site.travellaboratory.be.common.exception.BeApplicationException;
 import site.travellaboratory.be.common.exception.ErrorCodes;
 import site.travellaboratory.be.common.response.ApiErrorResponse;
 
+//@Profile("prod")
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/src/main/java/site/travellaboratory/be/controller/articleschedule/dto/ArticleScheduleRequest.java
+++ b/src/main/java/site/travellaboratory/be/controller/articleschedule/dto/ArticleScheduleRequest.java
@@ -10,6 +10,10 @@ public record ArticleScheduleRequest(
     Time visitedTime,
     Integer sortOrder,
     String category,
+    Time durationTime,
+    String expense,
+    String memo,
+
     String dtype,
     ScheduleGeneralRequest scheduleGeneral,
     ScheduleTransportRequest scheduleTransport,

--- a/src/main/java/site/travellaboratory/be/controller/articleschedule/dto/ScheduleGeneralRequest.java
+++ b/src/main/java/site/travellaboratory/be/controller/articleschedule/dto/ScheduleGeneralRequest.java
@@ -1,13 +1,8 @@
 package site.travellaboratory.be.controller.articleschedule.dto;
 
-import java.sql.Time;
-
 public record ScheduleGeneralRequest(
     String placeName,
-    Time durationTime,
-    String expense,
-    String memo,
-    Long googleMapPlaceId,
+    String googleMapPlaceId,
     Double googleMapLatitude,
     Double googleMapLongitude,
     String googleMapAddress,

--- a/src/main/java/site/travellaboratory/be/domain/articleschedule/ArticleSchedule.java
+++ b/src/main/java/site/travellaboratory/be/domain/articleschedule/ArticleSchedule.java
@@ -49,6 +49,15 @@ public abstract class ArticleSchedule extends BaseEntity {
     @Column(nullable = false, length = 15)
     private String category;
 
+    @Column(nullable = false, columnDefinition = "TIME(4)")
+    private Time durationTime;
+
+    @Column(nullable = false, length = 15)
+    private String expense;
+
+    @Column(length = 500)
+    private String memo;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ArticleScheduleStatus status;
@@ -63,12 +72,18 @@ public abstract class ArticleSchedule extends BaseEntity {
         Time visitedTime,
         Integer sortOrder,
         String category,
+        Time durationTime,
+        String expense,
+        String memo,
         ArticleScheduleStatus status) {
         this.article = article;
         this.visitedDate = visitedDate;
         this.visitedTime = visitedTime;
         this.sortOrder = sortOrder;
         this.category = category;
+        this.durationTime = durationTime;
+        this.expense = expense;
+        this.memo = memo;
         this.status = status;
     }
 
@@ -81,5 +96,8 @@ public abstract class ArticleSchedule extends BaseEntity {
         this.visitedTime = request.visitedTime();
         this.sortOrder = request.sortOrder();
         this.category = request.category();
+        this.durationTime = request.durationTime();
+        this.expense = request.expense();
+        this.memo = request.memo();
     }
 }

--- a/src/main/java/site/travellaboratory/be/domain/articleschedule/dtype/ScheduleEtc.java
+++ b/src/main/java/site/travellaboratory/be/domain/articleschedule/dtype/ScheduleEtc.java
@@ -28,12 +28,14 @@ public class ScheduleEtc extends ArticleSchedule {
         Article article,
         LocalDate visitedDate,
         Time visitedTime,
-        Integer sort_order,
+        Integer sortOrder,
         String category,
+        Time durationTime,
+        String expense,
+        String memo,
         ArticleScheduleStatus status,
-
         String placeName) {
-        super(article, visitedDate, visitedTime, sort_order, category,status);
+        super(article, visitedDate, visitedTime, sortOrder, category, durationTime, expense, memo, status);
         this.placeName = placeName;
     }
 
@@ -41,21 +43,24 @@ public class ScheduleEtc extends ArticleSchedule {
         Article article,
         LocalDate visitedDate,
         Time visitedTime,
-        Integer sort_order,
+        Integer sortOrder,
         String category,
+        Time durationTime,
+        String expense,
+        String memo,
         ArticleScheduleStatus status,
-
-
         ScheduleEtcRequest request
         ) {
         return new ScheduleEtc(
             article,
             visitedDate,
             visitedTime,
-            sort_order,
+            sortOrder,
             category,
+            durationTime,
+            expense,
+            memo,
             status,
-
             request.placeName());
     }
 

--- a/src/main/java/site/travellaboratory/be/domain/articleschedule/dtype/ScheduleGeneral.java
+++ b/src/main/java/site/travellaboratory/be/domain/articleschedule/dtype/ScheduleGeneral.java
@@ -24,17 +24,8 @@ public class ScheduleGeneral extends ArticleSchedule {
     @Column(nullable = false, length = 255)
     private String placeName;
 
-    @Column(nullable = false, columnDefinition = "TIME(4)")
-    private Time durationTime;
-
-    @Column(nullable = false, length = 15)
-    private String expense;
-
-    @Column(length = 500)
-    private String memo;
-
-    @Column(nullable = false)
-    private Long googleMapPlaceId;
+    @Column(nullable = false, length = 255)
+    private String googleMapPlaceId;
 
     @Column(nullable = false, columnDefinition = "DECIMAL(10,8)")
     private Double googleMapLatitude;
@@ -56,26 +47,23 @@ public class ScheduleGeneral extends ArticleSchedule {
         Article article,
         LocalDate visitedDate,
         Time visitedTime,
-        Integer sort_order,
+        Integer sortOrder,
         String category,
-        ArticleScheduleStatus status,
-
-        String placeName,
         Time durationTime,
         String expense,
         String memo,
-        Long googleMapPlaceId,
+        ArticleScheduleStatus status,
+
+        String placeName,
+        String googleMapPlaceId,
         Double googleMapLatitude,
         Double googleMapLongitude,
         String googleMapAddress,
         String googleMapPhoneNumber,
         String googleMapHomePageUrl
         ) {
-        super(article, visitedDate, visitedTime, sort_order, category, status);
+        super(article, visitedDate, visitedTime, sortOrder, category, durationTime, expense, memo, status);
         this.placeName = placeName;
-        this.durationTime = durationTime;
-        this.expense = expense;
-        this.memo = memo;
         this.googleMapPlaceId = googleMapPlaceId;
         this.googleMapLatitude = googleMapLatitude;
         this.googleMapLongitude = googleMapLongitude;
@@ -88,8 +76,11 @@ public class ScheduleGeneral extends ArticleSchedule {
         Article article,
         LocalDate visitedDate,
         Time visitedTime,
-        Integer sort_order,
+        Integer sortOrder,
         String category,
+        Time durationTime,
+        String expense,
+        String memo,
         ArticleScheduleStatus status,
 
         ScheduleGeneralRequest request
@@ -98,14 +89,14 @@ public class ScheduleGeneral extends ArticleSchedule {
             article,
             visitedDate,
             visitedTime,
-            sort_order,
+            sortOrder,
             category,
+            durationTime,
+            expense,
+            memo,
             status,
 
             request.placeName(),
-            request.durationTime(),
-            request.expense(),
-            request.memo(),
             request.googleMapPlaceId(),
             request.googleMapLatitude(),
             request.googleMapLongitude(),
@@ -117,9 +108,6 @@ public class ScheduleGeneral extends ArticleSchedule {
 
     public void update(ScheduleGeneralRequest request) {
         this.placeName = request.placeName();
-        this.durationTime = request.durationTime();
-        this.expense = request.expense();
-        this.memo = request.memo();
         this.googleMapPlaceId = request.googleMapPlaceId();
         this.googleMapLatitude = request.googleMapLatitude();
         this.googleMapLongitude = request.googleMapLongitude();

--- a/src/main/java/site/travellaboratory/be/domain/articleschedule/dtype/ScheduleTransport.java
+++ b/src/main/java/site/travellaboratory/be/domain/articleschedule/dtype/ScheduleTransport.java
@@ -53,8 +53,11 @@ public class ScheduleTransport extends ArticleSchedule {
         Article article,
         LocalDate visitedDate,
         Time visitedTime,
-        Integer sort_order,
+        Integer sortOrder,
         String category,
+        Time durationTime,
+        String expense,
+        String memo,
         ArticleScheduleStatus status,
 
 
@@ -67,7 +70,7 @@ public class ScheduleTransport extends ArticleSchedule {
         String googleMapEndPlaceAddress,
         Double googleMapEndLatitude,
         Double googleMapEndLongitude) {
-        super(article, visitedDate, visitedTime, sort_order, category, status);
+        super(article, visitedDate, visitedTime, sortOrder, category, durationTime, expense, memo, status);
         this.transportation = transportation;
         this.startPlaceName = startPlaceName;
         this.googleMapStartPlaceAddress = googleMapStartPlaceAddress;
@@ -83,8 +86,11 @@ public class ScheduleTransport extends ArticleSchedule {
         Article article,
         LocalDate visitedDate,
         Time visitedTime,
-        Integer sort_order,
+        Integer sortOrder,
         String category,
+        Time durationTime,
+        String expense,
+        String memo,
         ArticleScheduleStatus status,
 
         ScheduleTransportRequest request
@@ -93,8 +99,11 @@ public class ScheduleTransport extends ArticleSchedule {
             article,
             visitedDate,
             visitedTime,
-            sort_order,
+            sortOrder,
             category,
+            durationTime,
+            expense,
+            memo,
             status,
 
             request.transportation(),

--- a/src/main/java/site/travellaboratory/be/service/ArticleScheduleService.java
+++ b/src/main/java/site/travellaboratory/be/service/ArticleScheduleService.java
@@ -118,6 +118,9 @@ public class ArticleScheduleService {
                     request.visitedTime(),
                     request.sortOrder(),
                     request.category(),
+                    request.durationTime(),
+                    request.expense(),
+                    request.memo(),
                     ArticleScheduleStatus.ACTIVE,
                     request.scheduleGeneral()
                 );
@@ -131,6 +134,9 @@ public class ArticleScheduleService {
                     request.visitedTime(),
                     request.sortOrder(),
                     request.category(),
+                    request.durationTime(),
+                    request.expense(),
+                    request.memo(),
                     ArticleScheduleStatus.ACTIVE,
                     request.scheduleTransport()
                 );
@@ -142,6 +148,9 @@ public class ArticleScheduleService {
                     request.visitedTime(),
                     request.sortOrder(),
                     request.category(),
+                    request.durationTime(),
+                    request.expense(),
+                    request.memo(),
                     ArticleScheduleStatus.ACTIVE,
                     request.scheduleEtc()
                 );


### PR DESCRIPTION
## 🧾 PR 관련 설명
- **작업 이유**: 
-  일정 리스트 수정 [생성, 수정, 삭제] - ScheduleGeneral 에만 있던 duration_time, expense, memo 를 ArticleSchedule (공통) 으로 수정

- **관련 이슈**:  ❌

<br/>

## ✨ 주요 작업 내용
- ScheduleGeneral 에만 있던 duration_time, expense, memo 를 ArticleSchedule (공통) 으로 수정

<br/>

## ✅ 체크리스트
- [x] Build 성공?!
- [ ] Test 작성 완료?!
- [x] 포스트맨 테스트
- [x] 필요한 경우 문서를 업데이트했습니다.

<br/>
