### PR TITLE
fix: PATCH - /article/status/{articleId} 삭제 (중복 코드)

### DIFF
--- a/src/main/java/site/travellaboratory/be/article/application/service/ArticleWriterService.java
+++ b/src/main/java/site/travellaboratory/be/article/application/service/ArticleWriterService.java
@@ -12,7 +12,6 @@ import site.travellaboratory.be.article.domain.request.ArticleRegisterRequest;
 import site.travellaboratory.be.article.domain.request.ArticleUpdateRequest;
 import site.travellaboratory.be.article.infrastructure.persistence.entity.ArticleEntity;
 import site.travellaboratory.be.article.infrastructure.persistence.repository.ArticleJpaRepository;
-import site.travellaboratory.be.article.presentation.response.writer.ArticleDeleteResponse;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdateCoverImageResponse;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdatePrivacyResponse;
 import site.travellaboratory.be.common.exception.BeApplicationException;
@@ -71,22 +70,6 @@ public class ArticleWriterService {
         return articleJpaRepository.save(ArticleEntity.from(article)).toModel();
     }
 
-    // 아티클 삭제
-    @Transactional
-    public ArticleDeleteResponse deleteArticle(Long userId, Long articleId) {
-        User user = userJpaRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
-            .orElseThrow(() -> new BeApplicationException(ErrorCodes.USER_NOT_FOUND,
-                HttpStatus.NOT_FOUND)).toModel();
-
-        Article article = articleJpaRepository.findByIdAndStatusIn(articleId,
-                List.of(ArticleStatus.ACTIVE, ArticleStatus.PRIVATE))
-            .orElseThrow(() -> new BeApplicationException(ErrorCodes.ARTICLE_NOT_FOUND, HttpStatus.NOT_FOUND)).toModel();
-
-
-        article = article.delete(user);
-        articleJpaRepository.save(ArticleEntity.from(article));
-        return ArticleDeleteResponse.from(true);
-    }
 
     // articleService_에 가는 게 맞는 로직
     @Transactional

--- a/src/main/java/site/travellaboratory/be/article/presentation/controller/ArticleWriterController.java
+++ b/src/main/java/site/travellaboratory/be/article/presentation/controller/ArticleWriterController.java
@@ -13,15 +13,14 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import site.travellaboratory.be.article.application.service.ArticleWriterService;
-import site.travellaboratory.be.common.annotation.UserId;
 import site.travellaboratory.be.article.domain.Article;
-import site.travellaboratory.be.article.presentation.response.writer.ArticleDeleteResponse;
 import site.travellaboratory.be.article.domain.request.ArticleRegisterRequest;
+import site.travellaboratory.be.article.domain.request.ArticleUpdateRequest;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleRegisterResponse;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdateCoverImageResponse;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdatePrivacyResponse;
-import site.travellaboratory.be.article.domain.request.ArticleUpdateRequest;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdateResponse;
+import site.travellaboratory.be.common.annotation.UserId;
 
 @RestController
 @RequiredArgsConstructor
@@ -58,16 +57,6 @@ public class ArticleWriterController {
         Article result = articleWriterService.updateArticle(userId, articleId,
             articleUpdateRequest);
         return ResponseEntity.ok(ArticleUpdateResponse.from(result));
-    }
-
-    @PatchMapping("/article/status/{articleId}")
-    public ResponseEntity<ArticleDeleteResponse> deleteArticle(
-        @UserId final Long userId,
-        @PathVariable(name = "articleId") final Long articleId
-    ) {
-        ArticleDeleteResponse articleDeleteResponse = articleWriterService.deleteArticle(userId,
-            articleId);
-        return ResponseEntity.ok(articleDeleteResponse);
     }
 
     // articleWriterService_에 가는 게 맞는 로직 - 상권 (여행 계획 - 공개, 비공개 설정)

--- a/src/test/java/site/travellaboratory/be/article/application/ArticleWriterServiceTest.java
+++ b/src/test/java/site/travellaboratory/be/article/application/ArticleWriterServiceTest.java
@@ -29,7 +29,6 @@ import site.travellaboratory.be.article.domain.request.ArticleUpdateRequest;
 import site.travellaboratory.be.article.domain.request.LocationRequest;
 import site.travellaboratory.be.article.infrastructure.persistence.entity.ArticleEntity;
 import site.travellaboratory.be.article.infrastructure.persistence.repository.ArticleJpaRepository;
-import site.travellaboratory.be.article.presentation.response.writer.ArticleDeleteResponse;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdateCoverImageResponse;
 import site.travellaboratory.be.article.presentation.response.writer.ArticleUpdatePrivacyResponse;
 import site.travellaboratory.be.common.exception.BeApplicationException;
@@ -193,51 +192,6 @@ class ArticleWriterServiceTest {
         assertThat(updateArticle.getTravelStyles().stream()
                 .map(TravelStyle::getName)).containsExactlyElementsOf(
                 articleUpdateRequest().travelStyles());
-    }
-
-    @DisplayName("올바르지 않은 유저가 게시물을 삭제하려고 하면 예외가 발생한다.")
-    @Test
-    void deleteArticle_test_ifUserIsNotFound() {
-        //given
-        when(userJpaRepository.findByIdAndStatus(any(Long.class), eq(UserStatus.ACTIVE)))
-                .thenReturn(Optional.empty());
-
-        //when & then
-        assertThatThrownBy(() -> articleWriterService.deleteArticle(1L, 1L)).isInstanceOf(
-                BeApplicationException.class);
-    }
-
-    @DisplayName("유효하지 않은 게시물을 삭제하려고 하면 예외가 발생한다.")
-    @Test
-    void deleteArticle_test_ifArticleIsNotFound() {
-        //given
-        when(userJpaRepository.findByIdAndStatus(any(Long.class), eq(UserStatus.ACTIVE)))
-                .thenReturn(Optional.of(UserEntity.from(user())));
-        when(articleJpaRepository.findByIdAndStatusIn(any(Long.class), any(List.class)))
-                .thenReturn(Optional.empty());
-
-        //when & then
-        assertThatThrownBy(() -> articleWriterService.deleteArticle(1L, 1L)).isInstanceOf(
-                BeApplicationException.class);
-    }
-
-    @DisplayName("게시물 삭제 성공 테스트")
-    @Test
-    void deleteArticle_test_success() {
-        //given
-        final Article article = Article.create(user(), articleRegisterRequest());
-        final ArticleEntity articleEntity = ArticleEntity.from(article);
-
-        when(userJpaRepository.findByIdAndStatus(any(Long.class), eq(UserStatus.ACTIVE)))
-                .thenReturn(Optional.of(UserEntity.from(user())));
-        when(articleJpaRepository.findByIdAndStatusIn(any(Long.class), any(List.class)))
-                .thenReturn(Optional.of(articleEntity));
-
-        //when
-        final ArticleDeleteResponse articleDeleteResponse = articleWriterService.deleteArticle(1L, 1L);
-
-        //then
-        assertThat(articleDeleteResponse.isDelete()).isEqualTo(true);
     }
 
     @DisplayName("유효하지 않은 게시물의 접근 권한을 변경하려고 할 경우 예외가 발생한다.")


### PR DESCRIPTION
## 🧾 PR 관련 설명
- **작업 이유**: 
- 같은 기능을 ArticleSchedule에서도 구현
- 하지만 ArticleScheduleService의 경우 ArticleScheduleRepository를 의존하기에 해당 부분이 좀더 적합하다고 판단 그렇기에 ArticleWriterService에서 삭제 및 관련 코드 삭제

<br/>

## ✅ 체크리스트
- [x] Build 성공?!
- [x] Test 작성 완료?!
- [x] 필요한 경우 문서를 업데이트했습니다.